### PR TITLE
 Supports async API as of release 211

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: groovy

--- a/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceController.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceController.java
@@ -57,22 +57,23 @@ public class ServiceInstanceController extends BaseController {
 		
 	}
 	
-	@RequestMapping(value = BASE_PATH + "/{instanceId}", method = RequestMethod.GET)
-	public ResponseEntity<?> getServiceInstance(
+	@RequestMapping(value = BASE_PATH + "/{instanceId}/last_operation", method = RequestMethod.GET)
+	public ResponseEntity<?> getServiceInstanceLastOperation(
 			@PathVariable("instanceId") String instanceId) {
-		
-		logger.debug("GET: " + BASE_PATH + "/{instanceId}" 
+
+		logger.debug("GET: " + BASE_PATH + "/{instanceId}/last_operation"
 				+ ", getServiceInstance(), serviceInstanceId = " + instanceId);
-		
+
 		ServiceInstance instance = service.getServiceInstance(instanceId);
-		
+
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
-		if (null == instance) { 
+		if (null == instance) {
 			return new ResponseEntity<String>("{}", headers, HttpStatus.GONE);
-		} 
-		logger.debug("ServiceInstance: " + instance.getServiceInstanceId());
-		return new ResponseEntity<ServiceInstance>(instance, headers, HttpStatus.OK);
+		}
+		ServiceInstanceLastOperation lastOperation = instance.getServiceInstanceLastOperation();
+		logger.debug("ServiceInstance: " + instance.getServiceInstanceId() + "is in " +lastOperation.getState() + " state. Details : " +lastOperation.getDescription());
+		return new ResponseEntity<ServiceInstanceLastOperation>(lastOperation, headers, HttpStatus.OK);
 	}
 	
 	@RequestMapping(value = BASE_PATH + "/{instanceId}", method = RequestMethod.DELETE)

--- a/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstanceLastOperation.java
+++ b/src/main/java/org/cloudfoundry/community/servicebroker/model/ServiceInstanceLastOperation.java
@@ -16,10 +16,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public class ServiceInstanceLastOperation {
 
 	@JsonSerialize
-	@JsonProperty("dashboard_url")
-	private String dashboarUrl;
-
-	@JsonSerialize
 	private String description;
 
 	private OperationState state;

--- a/src/test/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/controller/ServiceInstanceControllerIntegrationTest.java
@@ -1,0 +1,236 @@
+package org.cloudfoundry.community.servicebroker.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.cloudfoundry.community.servicebroker.exception.*;
+import org.cloudfoundry.community.servicebroker.model.*;
+import org.cloudfoundry.community.servicebroker.model.fixture.*;
+import org.cloudfoundry.community.servicebroker.service.*;
+import org.junit.*;
+import org.mockito.*;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+public class ServiceInstanceControllerIntegrationTest {
+		
+	MockMvc mockMvc;
+
+	@InjectMocks
+	ServiceInstanceController controller;
+
+	@Mock
+	ServiceInstanceService serviceInstanceService;
+	
+	@Mock
+	CatalogService catalogService;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+
+	    this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
+	            .setMessageConverters(new MappingJackson2HttpMessageConverter()).build();
+	}
+	
+	@Test
+	public void serviceInstanceIsCreatedCorrectly() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+		
+		when(serviceInstanceService.createServiceInstance(any(CreateServiceInstanceRequest.class)))
+	    	.thenReturn(instance);
+	    
+		when(catalogService.getServiceDefinition(any(String.class)))
+    	.thenReturn(ServiceFixture.getService());
+		
+	    String dashboardUrl = "dashboard_url";
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String body = ServiceInstanceFixture.getCreateServiceInstanceRequestJson();
+	    
+	    mockMvc.perform(
+	    		put(url)
+	    		.contentType(MediaType.APPLICATION_JSON)
+	    		.content(body)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isCreated())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.dashboard_url", is(dashboardUrl)));
+ 	}
+	
+	@Test
+	public void unknownServiceDefinitionInstanceCreationFails() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+	    
+		when(catalogService.getServiceDefinition(any(String.class)))
+    	.thenReturn(null);
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String body = ServiceInstanceFixture.getCreateServiceInstanceRequestJson();
+	    
+	    mockMvc.perform(
+	    		put(url)
+	    		.contentType(MediaType.APPLICATION_JSON)
+	    		.content(body)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isUnprocessableEntity())
+	    	.andExpect(jsonPath("$.description", containsString(instance.getServiceDefinitionId())));
+ 	}
+	
+	@Test
+	public void duplicateServiceInstanceCreationFails() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+	    
+	    when(catalogService.getServiceDefinition(any(String.class)))
+    	.thenReturn(ServiceFixture.getService());
+	    
+		when(serviceInstanceService.createServiceInstance(any(CreateServiceInstanceRequest.class)))
+	    	.thenThrow(new ServiceInstanceExistsException(instance));
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String body = ServiceInstanceFixture.getCreateServiceInstanceRequestJson();
+	    
+	    mockMvc.perform(
+	    		put(url)
+	    		.contentType(MediaType.APPLICATION_JSON)
+	    		.content(body)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isConflict())
+	    	.andExpect(jsonPath("$.description", containsString(instance.getServiceInstanceId())));
+ 	}
+	
+	@Test
+	public void badJsonServiceInstanceCreationFails() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+		
+		when(serviceInstanceService.createServiceInstance(any(CreateServiceInstanceRequest.class)))
+	    	.thenReturn(instance);
+	    
+		when(catalogService.getServiceDefinition(any(String.class)))
+    	.thenReturn(ServiceFixture.getService());
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String body = ServiceInstanceFixture.getCreateServiceInstanceRequestJson();
+	    body = body.replace("service_id", "foo");
+	    
+	    mockMvc.perform(
+	    		put(url)
+	    		.contentType(MediaType.APPLICATION_JSON)
+	    		.content(body)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isUnprocessableEntity())
+	    	.andExpect(jsonPath("$.description", containsString("Missing required fields")));
+ 	}
+	
+	@Test
+	public void badJsonServiceInstanceCreationFailsMissingFields() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+		
+		when(serviceInstanceService.createServiceInstance(any(CreateServiceInstanceRequest.class)))
+	    	.thenReturn(instance);
+	    
+		when(catalogService.getServiceDefinition(any(String.class)))
+    	.thenReturn(ServiceFixture.getService());
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String body = "{}";
+	    
+	    mockMvc.perform(
+	    		put(url)
+	    		.contentType(MediaType.APPLICATION_JSON)
+	    		.content(body)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isUnprocessableEntity())
+	    	.andExpect(jsonPath("$.description", containsString("serviceDefinitionId")))
+	    	.andExpect(jsonPath("$.description", containsString("planId")))
+	    	.andExpect(jsonPath("$.description", containsString("organizationGuid")))
+	    	.andExpect(jsonPath("$.description", containsString("spaceGuid")));
+ 	}
+	
+	@Test
+	public void serviceInstanceIsDeletedSuccessfully() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+			    
+		when(serviceInstanceService.deleteServiceInstance(any(DeleteServiceInstanceRequest.class)))
+    		.thenReturn(instance);
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() 
+	    		+ "?service_id=" + instance.getServiceDefinitionId()
+	    		+ "&plan_id=" + instance.getPlanId();
+	    
+	    mockMvc.perform(delete(url)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", is(not("{}")))
+        );
+ 	}
+	
+	@Test
+	public void deleteUnknownServiceInstanceFailsWithA410() throws Exception {
+	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+			    
+		when(serviceInstanceService.deleteServiceInstance(any(DeleteServiceInstanceRequest.class)))
+    		.thenReturn(null);
+	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() 
+	    		+ "?service_id=" + instance.getServiceDefinitionId()
+	    		+ "&plan_id=" + instance.getPlanId();
+	    
+	    mockMvc.perform(delete(url)
+	    		.accept(MediaType.APPLICATION_JSON)
+	    	)
+	    	.andExpect(status().isGone())
+	    	.andExpect(jsonPath("$", is("{}")));
+ 	}
+
+	@Test
+	public void serviceInstanceIsUpdatedSuccessfully() throws Exception {
+		ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+
+		when(serviceInstanceService.updateServiceInstance(any(UpdateServiceInstanceRequest.class)))
+		.thenReturn(instance);
+
+		String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+
+		String body = ServiceInstanceFixture.getUpdateServiceInstanceRequestJson();
+
+		mockMvc.perform(
+				patch(url).contentType(MediaType.APPLICATION_JSON).content(body)
+				.accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$", is("{}")));
+	}
+
+	@Test
+	public void updateUnsupportedPlanFailsWithA422() throws Exception {
+		ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
+
+		when(serviceInstanceService.updateServiceInstance(any(UpdateServiceInstanceRequest.class)))
+		.thenThrow(new ServiceInstanceUpdateNotSupportedException("description"));
+
+		String url =
+				ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() + "?service_id="
+						+ instance.getServiceDefinitionId() + "&plan_id=" + instance.getPlanId();
+		String body = ServiceInstanceFixture.getUpdateServiceInstanceRequestJson();
+
+		mockMvc.perform(
+				patch(url).contentType(MediaType.APPLICATION_JSON).content(body)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isUnprocessableEntity())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.description", containsString("description")));
+	}
+
+}

--- a/src/test/java/org/cloudfoundry/community/servicebroker/model/fixture/ServiceInstanceControllerIntegrationTest.java
+++ b/src/test/java/org/cloudfoundry/community/servicebroker/model/fixture/ServiceInstanceControllerIntegrationTest.java
@@ -345,7 +345,7 @@ public class ServiceInstanceControllerIntegrationTest {
 	@Test
 	public void itShouldReturnAnInProgressServiceInstance() throws Exception {
 	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
-	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() + "/last_operation";
 	    
 	    when(serviceInstanceService.getServiceInstance(any(String.class))).thenReturn(
 	    		ServiceInstanceFixture.getAsyncServiceInstance().withLastOperation(
@@ -354,13 +354,13 @@ public class ServiceInstanceControllerIntegrationTest {
 				get(url))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.last_operation.state", is("in progress")));
+				.andExpect(jsonPath("$.state", is("in progress")));
 	}
 	
 	@Test
 	public void itShouldReturnAFailedServiceInstance() throws Exception {
 	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
-	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() + "/last_operation";
 	    
 	    when(serviceInstanceService.getServiceInstance(any(String.class))).thenReturn(
 	    		ServiceInstanceFixture.getAsyncServiceInstance().withLastOperation(
@@ -369,14 +369,14 @@ public class ServiceInstanceControllerIntegrationTest {
 				get(url))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.last_operation.state", is("failed")));
+				.andExpect(jsonPath("$.state", is("failed")));
 	}
 	
 	@Test
 	public void itShouldReturnASucceededServiceInstance() throws Exception {
 	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
-	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
-	    
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() + "/last_operation";
+
 	    when(serviceInstanceService.getServiceInstance(any(String.class))).thenReturn(
 	    		ServiceInstanceFixture.getAsyncServiceInstance().withLastOperation(
 	    				new ServiceInstanceLastOperation("mucho working", OperationState.SUCCEEDED)));
@@ -384,14 +384,14 @@ public class ServiceInstanceControllerIntegrationTest {
 				get(url))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.last_operation.state", is("succeeded")));
+				.andExpect(jsonPath("$.state", is("succeeded")));
 	}
 	
 
 	@Test
 	public void itShouldReturnGoneIfTheServiceInstanceDoesNotExist() throws Exception { 
 	    ServiceInstance instance = ServiceInstanceFixture.getServiceInstance();
-	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId();
+	    String url = ServiceInstanceController.BASE_PATH + "/" + instance.getServiceInstanceId() + "/last_operation";
 	    
 	    when(serviceInstanceService.getServiceInstance(any(String.class))).thenReturn(null);
 		mockMvc.perform(


### PR DESCRIPTION
release 211 requires for the broker to expose polling capabilies at /v2/service_instances/:guid/last_operation.
This endpoint will replace former /v2/service_instances/:guid endpoint
